### PR TITLE
Add audio player and wave effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,11 @@
         <div class="visualizer" aria-hidden="true">
             <span></span><span></span><span></span><span></span><span></span>
         </div>
+        <div class="audio-player">
+            <button id="audioToggle" aria-label="Pause music">⏸</button>
+            <input id="volumeControl" type="range" min="0" max="1" step="0.01" aria-label="Volume">
+        </div>
+        <audio id="bgAudio" src="https://cdn.pixabay.com/download/audio/2022/03/01/audio_a2f26c95d2.mp3?filename=afternoon-110883.mp3" autoplay loop></audio>
         <a href="#spotify" class="btn">Poslouchejte na Spotify</a>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -29,4 +29,39 @@ document.addEventListener('DOMContentLoaded', () => {
         document.body.classList.toggle('dark-mode');
         localStorage.setItem('theme', document.body.classList.contains('dark-mode') ? 'dark' : 'light');
     });
+
+    // Custom audio player
+    const audio = document.getElementById('bgAudio');
+    const toggleBtn = document.getElementById('audioToggle');
+    const volumeControl = document.getElementById('volumeControl');
+    if (audio && toggleBtn && volumeControl) {
+        volumeControl.value = audio.volume;
+        toggleBtn.addEventListener('click', () => {
+            if (audio.paused) {
+                audio.play();
+                toggleBtn.textContent = '⏸';
+                toggleBtn.setAttribute('aria-label', 'Pause music');
+            } else {
+                audio.pause();
+                toggleBtn.textContent = '▶';
+                toggleBtn.setAttribute('aria-label', 'Play music');
+            }
+        });
+        volumeControl.addEventListener('input', () => {
+            audio.volume = volumeControl.value;
+        });
+    }
+
+    // Wave effect on hero background
+    const hero = document.getElementById('hero');
+    if (hero) {
+        hero.addEventListener('mousemove', (e) => {
+            const wave = document.createElement('span');
+            wave.className = 'wave';
+            wave.style.left = `${e.clientX}px`;
+            wave.style.top = `${e.clientY}px`;
+            hero.appendChild(wave);
+            wave.addEventListener('animationend', () => wave.remove());
+        });
+    }
 });

--- a/style.css
+++ b/style.css
@@ -101,6 +101,7 @@ body.dark-mode {
 }
 
 .hero-section {
+    position: relative;
     height: 100vh;
     display: flex;
     flex-direction: column;
@@ -109,6 +110,7 @@ body.dark-mode {
     background: var(--gradient);
     text-align: center;
     padding: 0 1rem;
+    overflow: hidden;
 }
 
 
@@ -241,6 +243,50 @@ section {
     text-align: center;
     padding: 1rem 0;
     background: rgba(0,0,0,0.05);
+}
+
+.audio-player {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.audio-player button {
+    width: 40px;
+    height: 40px;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    background: var(--accent-color);
+    color: #fff;
+    font-size: 1rem;
+}
+
+.audio-player input[type="range"] {
+    width: 100px;
+}
+
+#bgAudio {
+    display: none;
+}
+
+.wave {
+    position: absolute;
+    pointer-events: none;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.4);
+    transform: translate(-50%, -50%) scale(0);
+    animation: ripple 0.6s ease-out;
+}
+
+@keyframes ripple {
+    to {
+        transform: translate(-50%, -50%) scale(8);
+        opacity: 0;
+    }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- add a custom audio player to the hero section
- style player and create ripple animation
- enable play/pause and volume controls via JavaScript
- create mouse wave effect on landing background

## Testing
- `node -v`
- `node -e "require('fs').readFileSync('script.js','utf8')" >/dev/null && echo "js parsed"`


------
https://chatgpt.com/codex/tasks/task_e_68856193dbf08323b5439d4c374ab6a9